### PR TITLE
Возвращение старого освещения

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -122,10 +122,10 @@
   components:
   - type: LightBulb
     bulb: Bulb
-    color: "#be885e" 
-    lightEnergy: 2
+    color: "#FFD1A3" # 4000K color temp
+    lightEnergy: 1.0
     lightRadius: 6
-    lightSoftness: 1
+    lightSoftness: 1.1
   - type: Tag
     tags:
     - LightBulb
@@ -215,9 +215,9 @@
   description: A light fixture.
   components:
   - type: LightBulb
-    color: "#bac9d6" 
-    lightEnergy: 0.6
-    lightRadius: 7
+    color: "#FFE4CE" # 5000K color temp
+    lightEnergy: 0.8
+    lightRadius: 10
     lightSoftness: 1
     PowerUse: 25
 

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -33,9 +33,9 @@
       shader: unshaded
     state: base
   - type: PointLight
-    color: "#bac9d6" # Cats edit 
-    energy: 0.7
-    radius: 8
+    color: "#FFE4CE" # 5000K color temp
+    energy: 0.8
+    radius: 10
     softness: 1
     offset: "0, -0.5"
   - type: Damageable
@@ -155,7 +155,7 @@
   - type: PoweredLight
     hasLampOnSpawn: LedLightTube
   - type: PointLight
-    radius: 7
+    radius: 15
     energy: 1
     softness: 0.9
     color: "#EEEEFF"
@@ -171,8 +171,8 @@
   suffix: Always Powered, LED
   components:
   - type: PointLight
-    radius: 7
-    energy: 1
+    radius: 10
+    energy: 2.5
     softness: 0.9
     color: "#EEEEFF"
 
@@ -198,7 +198,7 @@
   components:
   - type: PointLight
     radius: 12
-    energy: 2.5
+    energy: 4.5
     softness: 0.5
     color: "#B4FCF0"
 
@@ -335,7 +335,7 @@
     state: base
   - type: PointLight
     enabled: true
-    radius: 7
+    radius: 8
     energy: 1
     softness: 1
     color: "#EEEEFF"
@@ -396,7 +396,7 @@
   - type: PointLight
     enabled: false
     radius: 5
-    energy: 2
+    energy: 0.6
     offset: "0, 0.4"
     color: "#7CFC00"
     mask: /Textures/_SpaceCats/Effects/LightMasks/double_cone.png # Cats edit
@@ -407,7 +407,7 @@
     startingCharge: 0
   - type: EmergencyLight
   - type: RotatingLight
-    speed: 50
+    speed: 40
   - type: Sprite
     sprite: Structures/Wallmounts/Lighting/emergency_light.rsi
     layers:
@@ -468,8 +468,8 @@
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalCyan
   - type: PointLight
-    radius: 7
-    energy: 0.8
+    radius: 8
+    energy: 3
     softness: 0.5
     color: "#47f8ff"
   - type: DamageOnInteract
@@ -484,8 +484,8 @@
   parent: AlwaysPoweredWallLight
   components:
   - type: PointLight
-    radius: 7
-    energy: 0.8
+    radius: 8
+    energy: 3
     softness: 0.5
     color: "#47f8ff"
 
@@ -497,8 +497,8 @@
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalBlue
   - type: PointLight
-    radius: 7
-    energy: 0.8
+    radius: 8
+    energy: 3
     softness: 0.5
     color: "#39a1ff"
   - type: DamageOnInteract
@@ -513,8 +513,8 @@
   parent: AlwaysPoweredWallLight
   components:
   - type: PointLight
-    radius: 7
-    energy: 0.8
+    radius: 8
+    energy: 3
     softness: 0.5
     color: "#39a1ff"
 
@@ -526,8 +526,8 @@
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalPink
   - type: PointLight
-    radius: 7
-    energy: 0.8
+    radius: 8
+    energy: 3
     softness: 0.5
     color: "#ff66cc"
   - type: DamageOnInteract
@@ -542,8 +542,8 @@
   parent: AlwaysPoweredWallLight
   components:
   - type: PointLight
-    radius: 7
-    energy: 0.8
+    radius: 8
+    energy: 3
     softness: 0.5
     color: "#ff66cc"
 
@@ -555,8 +555,8 @@
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalOrange
   - type: PointLight
-    radius: 7
-    energy: 0.8
+    radius: 8
+    energy: 3
     softness: 0.5
     color: "#ff8227"
   - type: DamageOnInteract
@@ -571,8 +571,8 @@
   parent: AlwaysPoweredWallLight
   components:
   - type: PointLight
-    radius: 7
-    energy: 0.8
+    radius: 8
+    energy: 3
     softness: 0.5
     color: "#ff8227"
 
@@ -584,8 +584,8 @@
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalRed
   - type: PointLight
-    radius: 7
-    energy: 0.8
+    radius: 8
+    energy: 3
     softness: 0.5
     color: "#fb4747"
   - type: DamageOnInteract
@@ -600,8 +600,8 @@
   parent: AlwaysPoweredWallLight
   components:
   - type: PointLight
-    radius: 7
-    energy: 0.8
+    radius: 8
+    energy: 3
     softness: 0.5
     color: "#fb4747"
 
@@ -613,8 +613,8 @@
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalGreen
   - type: PointLight
-    radius: 7
-    energy: 0.8
+    radius: 8
+    energy: 3
     softness: 0.5
     color: "#52ff39"
   - type: DamageOnInteract
@@ -629,7 +629,7 @@
   parent: AlwaysPoweredWallLight
   components:
   - type: PointLight
-    radius: 7
-    energy: 0.8
+    radius: 8
+    energy: 3
     softness: 0.5
     color: "#52ff39"


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR
<!-- Опишите здесь ваш Pull Request (PR). Что он изменяет? На что еще это может повлиять? -->
Светильники теперь светят на то же расстояние, с той же мощностью и тем же цветом что и раньше. Новое освещение слишком мрачное и холодное, и не подходит для большинства станций. Два скриншота для сравнения будут ниже.

## Медиа
<!-- Добавьте скриншоты/видео, для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте скриншоты, иначе он может быть закрыт. -->

![изображение](https://github.com/user-attachments/assets/e317f14a-6ca6-4cec-8ed7-2d58f819720d)
![изображение](https://github.com/user-attachments/assets/5ad6b583-0103-4d81-8955-811ec8659379)
